### PR TITLE
Add ruby console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 
 gem "dotenv"
 gem "jenkins_api_client"
+gem "pry"

--- a/ruby-client/api-console.rb
+++ b/ruby-client/api-console.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# An interactive ruby console for exploring the Jenkins API
+
+require 'bundler/setup'
+require 'dotenv'
+require 'jenkins_api_client'
+require 'pry'
+
+Dotenv.load!
+
+@client = JenkinsApi::Client.new(:server_ip => ENV['JENKINS_SERVER_IP'],
+                                 :server_port => ENV['JENKINS_SERVER_PORT'],
+                                 :username => ENV['JENKINS_USERNAME'],
+                                 :password => ENV['JENKINS_PASSWORD'])
+
+# @client contains a configured instance of the JenkinsApi::Client class
+binding.pry

--- a/ruby-client/list-jobs.rb
+++ b/ruby-client/list-jobs.rb
@@ -3,7 +3,7 @@
 require 'dotenv'
 require 'jenkins_api_client'
 
-Dotenv.load(File.join(File.dirname(File.dirname(__FILE__)), ".env")) || exit
+Dotenv.load!
 
 @client = JenkinsApi::Client.new(:server_ip => ENV['JENKINS_SERVER_IP'],
                                  :server_port => ENV['JENKINS_SERVER_PORT'],


### PR DESCRIPTION
This adds an interactive ruby console for exploring the Jenkins API. This works on my machine™ 😄:

```
jarvis  jenkins2-starter (lj-add-ruby-console)> ./ruby-client/api-console.rb

From: /Users/leejones/Development/leejones/jenkins2-starter/ruby-client/api-console.rb @ line 14 :

     9:                                  :server_port => ENV['JENKINS_SERVER_PORT'],
    10:                                  :username => ENV['JENKINS_USERNAME'],
    11:                                  :password => ENV['JENKINS_PASSWORD'])
    12:
    13: # @client contains a configured instance of the JenkinsApi::Client object
 => 14: binding.pry

[1] pry(main)> @client.get_jenkins_version
=> "2.0-rc-1"
```

I also edited the list jobs script with some stuff I discovered about the dotenv gem.
